### PR TITLE
feat: add .pck file support and fix quoted identifier parsing (v1.4.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plsql-outline",
-  "version": "1.0.0",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plsql-outline",
-      "version": "1.0.0",
+      "version": "1.4.8",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "16.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "plsql-outline",
   "displayName": "PL/SQL Outline",
   "description": "PL/SQL代码结构解析器和大纲视图",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "publisher": "EmonZhang3438",
   "icon": "res/Icon.png",
   "engines": {
@@ -160,18 +160,18 @@
       "editor/context": [
         {
           "command": "plsqlOutline.parseCurrentFile",
-          "when": "resourceExtname =~ /\\.(sql|pks|pkb|prc|fnc|trg)$/i",
+          "when": "resourceExtname =~ /\\.(sql|pks|pkb|pck|prc|fnc|trg)$/i",
           "group": "plsql@1"
         }
       ],
       "commandPalette": [
         {
           "command": "plsqlOutline.parseCurrentFile",
-          "when": "resourceExtname =~ /\\.(sql|pks|pkb|prc|fnc|trg)$/i"
+          "when": "resourceExtname =~ /\\.(sql|pks|pkb|pck|prc|fnc|trg)$/i"
         },
         {
           "command": "plsqlOutline.refresh",
-          "when": "resourceExtname =~ /\\.(sql|pks|pkb|prc|fnc|trg)$/i"
+          "when": "resourceExtname =~ /\\.(sql|pks|pkb|pck|prc|fnc|trg)$/i"
         },
         {
           "command": "plsqlOutline.toggleStructureBlocks"
@@ -181,11 +181,11 @@
         },
         {
           "command": "plsqlOutline.showStats",
-          "when": "resourceExtname =~ /\\.(sql|pks|pkb|prc|fnc|trg)$/i"
+          "when": "resourceExtname =~ /\\.(sql|pks|pkb|pck|prc|fnc|trg)$/i"
         },
         {
           "command": "plsqlOutline.exportResult",
-          "when": "resourceExtname =~ /\\.(sql|pks|pkb|prc|fnc|trg)$/i"
+          "when": "resourceExtname =~ /\\.(sql|pks|pkb|pck|prc|fnc|trg)$/i"
         }
       ]
     },
@@ -288,7 +288,7 @@
           "items": {
             "type": "string"
           },
-          "default": [".sql", ".fnc", ".fcn", ".prc", ".pks", ".pkb", ".typ"],
+          "default": [".sql", ".fnc", ".fcn", ".prc", ".pks", ".pkb", ".pck", ".typ"],
           "description": "支持解析的文件扩展名列表"
         }
       }
@@ -303,6 +303,7 @@
         "extensions": [
           ".pks",
           ".pkb",
+          ".pck",
           ".prc",
           ".fnc",
           ".trg"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -641,7 +641,7 @@ export class PLSQLOutlineExtension {
         
         // 从配置中获取支持的文件扩展名
         const config = vscode.workspace.getConfiguration('plsql-outline');
-        const configuredExtensions = config.get<string[]>('fileExtensions', ['.sql', '.fnc', '.fcn', '.prc', '.pks', '.pkb', '.typ']);
+        const configuredExtensions = config.get<string[]>('fileExtensions', ['.sql', '.fnc', '.fcn', '.prc', '.pks', '.pkb', '.pck', '.typ']);
         
         // 检查文件扩展名
         return configuredExtensions.some(ext => fileName.endsWith(ext.toLowerCase()));
@@ -900,7 +900,7 @@ export function activate(context: vscode.ExtensionContext): void {
             const fileName = document.fileName.toLowerCase();
             
             if (languageId === 'plsql' || languageId === 'sql' || 
-                ['.sql', '.pks', '.pkb', '.prc', '.fnc', '.trg'].some(ext => fileName.endsWith(ext))) {
+                ['.sql', '.pks', '.pkb', '.pck', '.prc', '.fnc', '.trg'].some(ext => fileName.endsWith(ext))) {
                 
                 // 延迟执行，确保扩展完全激活
                 setTimeout(() => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -381,6 +381,8 @@ export class PLSQLParser {
 
     /**
      * 匹配CREATE语句 - 优化版本
+     * 支持普通标识符、双引号标识符及可选的 schema 前缀
+     * 例: PKG_NAME / "PKG_NAME" / APPS.PKG_NAME / "APPS"."PKG_NAME"
      */
     private matchCreateStatement(line: string): { type: NodeType; name: string } | null {
         // 使用缓存的正则表达式结果
@@ -392,30 +394,49 @@ export class PLSQLParser {
 
         let result: { type: NodeType; name: string } | null = null;
 
+        // 从匹配结果中提取对象名（去除引号和 schema 前缀）
+        // group[1] = 引号内的名称, group[2] = 无引号的名称
+        const extractName = (m: RegExpMatchArray): string =>
+            (m[1] || m[2] || '').replace(/"/g, '');
+
+        // 标识符模式：支持可选 schema 前缀（带或不带引号）
+        // 匹配: XXCUST_TEST_PKG / "XXCUST_TEST_PKG" / APPS.PKG / "APPS"."PKG"
+        const idPat = String.raw`(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"([^"]+)"|([\w][\w$#]*))`;
+
         // CREATE OR REPLACE PACKAGE BODY (必须先匹配，因为包含PACKAGE关键字)
-        let match = line.match(/^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PACKAGE\s+BODY\s+(\w+)/i);
+        let match = line.match(
+            new RegExp(String.raw`^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PACKAGE\s+BODY\s+` + idPat, 'i')
+        );
         if (match) {
-            result = { type: NodeType.PACKAGE_BODY, name: match[1] };
+            result = { type: NodeType.PACKAGE_BODY, name: extractName(match) };
         } else {
             // CREATE OR REPLACE PACKAGE (不包含BODY)
-            match = line.match(/^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PACKAGE\s+(?!BODY\s)(\w+)/i);
+            match = line.match(
+                new RegExp(String.raw`^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PACKAGE\s+(?!BODY\b)` + idPat, 'i')
+            );
             if (match) {
-                result = { type: NodeType.PACKAGE_HEADER, name: match[1] };
+                result = { type: NodeType.PACKAGE_HEADER, name: extractName(match) };
             } else {
                 // CREATE OR REPLACE FUNCTION
-                match = line.match(/^\s*CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(\w+)/i);
+                match = line.match(
+                    new RegExp(String.raw`^\s*CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+` + idPat, 'i')
+                );
                 if (match) {
-                    result = { type: NodeType.FUNCTION, name: match[1] };
+                    result = { type: NodeType.FUNCTION, name: extractName(match) };
                 } else {
                     // CREATE OR REPLACE PROCEDURE
-                    match = line.match(/^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+(\w+)/i);
+                    match = line.match(
+                        new RegExp(String.raw`^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+` + idPat, 'i')
+                    );
                     if (match) {
-                        result = { type: NodeType.PROCEDURE, name: match[1] };
+                        result = { type: NodeType.PROCEDURE, name: extractName(match) };
                     } else {
                         // CREATE OR REPLACE TRIGGER
-                        match = line.match(/^\s*CREATE\s+(?:OR\s+REPLACE\s+)?TRIGGER\s+(\w+)/i);
+                        match = line.match(
+                            new RegExp(String.raw`^\s*CREATE\s+(?:OR\s+REPLACE\s+)?TRIGGER\s+` + idPat, 'i')
+                        );
                         if (match) {
-                            result = { type: NodeType.TRIGGER, name: match[1] };
+                            result = { type: NodeType.TRIGGER, name: extractName(match) };
                         }
                     }
                 }

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -6,28 +6,29 @@ import { KeywordPattern, FileType, NodeType } from './types';
 export class KeywordPatterns {
     /**
      * CREATE OR REPLACE PACKAGE 模式
+     * 支持普通标识符、双引号标识符及可选 schema 前缀
      */
-    static readonly CREATE_PACKAGE = /^\s*CREATE\s+OR\s+REPLACE\s+PACKAGE\s+(\w+)\s*(?:AS|IS)?\s*$/i;
+    static readonly CREATE_PACKAGE = /^\s*CREATE\s+OR\s+REPLACE\s+PACKAGE\s+(?!BODY\b)(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"[^"]+"|\w[\w$#]*)\s*(?:AS|IS)?\s*$/i;
 
     /**
      * CREATE OR REPLACE PACKAGE BODY 模式
      */
-    static readonly CREATE_PACKAGE_BODY = /^\s*CREATE\s+OR\s+REPLACE\s+PACKAGE\s+BODY\s+(\w+)\s*(?:AS|IS)?\s*$/i;
+    static readonly CREATE_PACKAGE_BODY = /^\s*CREATE\s+OR\s+REPLACE\s+PACKAGE\s+BODY\s+(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"[^"]+"|\w[\w$#]*)\s*(?:AS|IS)?\s*$/i;
 
     /**
      * CREATE OR REPLACE FUNCTION 模式
      */
-    static readonly CREATE_FUNCTION = /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(\w+)/i;
+    static readonly CREATE_FUNCTION = /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"[^"]+"|\w[\w$#]*)/i;
 
     /**
      * CREATE OR REPLACE PROCEDURE 模式
      */
-    static readonly CREATE_PROCEDURE = /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+(\w+)/i;
+    static readonly CREATE_PROCEDURE = /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"[^"]+"|\w[\w$#]*)/i;
 
     /**
      * CREATE OR REPLACE TRIGGER 模式
      */
-    static readonly CREATE_TRIGGER = /^\s*CREATE\s+OR\s+REPLACE\s+TRIGGER\s+(\w+)/i;
+    static readonly CREATE_TRIGGER = /^\s*CREATE\s+OR\s+REPLACE\s+TRIGGER\s+(?:(?:"[^"]+"|[\w$#]+)\.)*(?:"[^"]+"|\w[\w$#]*)/i;
 
     /**
      * 内部函数/过程声明模式
@@ -205,6 +206,8 @@ export class FileTypeDetector {
                 return FileType.PACKAGE_HEADER;
             case 'pkb':
                 return FileType.PACKAGE_BODY;
+            case 'pck':
+                return FileType.UNKNOWN; // 包含 header + body，通过内容检测
             case 'prc':
                 return FileType.STANDALONE_PROCEDURE;
             case 'fnc':

--- a/test/XXCUST_TEST_PKG.pck
+++ b/test/XXCUST_TEST_PKG.pck
@@ -1,0 +1,201 @@
+
+  CREATE OR REPLACE PACKAGE "APPS"."XXCUST_TEST_PKG" AS
+
+  g_Tab         VARCHAR2(1) := Chr(9);
+  g_Change_Line VARCHAR2(2) := Chr(10) || Chr(13);
+  g_Line        VARCHAR2(150) := Rpad('-', 150, '-');
+  g_Space       VARCHAR2(40) := Chr(38) || 'nbsp';
+
+  g_Last_Updated_Date DATE := SYSDATE;
+  g_Last_Updated_By   NUMBER := Fnd_Global.User_Id;
+  g_Creation_Date     DATE := SYSDATE;
+  g_Created_By        NUMBER := Fnd_Global.User_Id;
+  g_Last_Update_Login NUMBER := Fnd_Global.Login_Id;
+
+  g_Request_Id NUMBER := Fnd_Global.Conc_Request_Id;
+  g_Session_Id NUMBER := Userenv('sessionid');
+
+  --main
+  PROCEDURE Main(Errbuf       OUT VARCHAR2
+                ,Retcode      OUT VARCHAR2
+                ,p_Parameter1 IN VARCHAR2);
+
+END xxcust_test_pkg;
+/
+CREATE OR REPLACE PACKAGE BODY "APPS"."XXCUST_TEST_PKG" AS
+
+  -- Global variable
+  g_Pkg_Name CONSTANT VARCHAR2(30) := 'xxcust_test_pkg';
+  -- Debug Enabled
+  l_Debug VARCHAR2(1) := Nvl(Fnd_Profile.Value('AFLOG_ENABLED'), 'N');
+
+  --output
+  PROCEDURE Output(p_Content IN VARCHAR2) IS
+  BEGIN
+    Fnd_File.Put_Line(Fnd_File.Output, p_Content);
+  END Output;
+
+--log
+  PROCEDURE Log(p_Content IN VARCHAR2) IS
+  BEGIN
+    Fnd_File.Put_Line(Fnd_File.Log, to_char(sysdate,'yyyy-mm-dd hh24:mi:ss')||'->'||p_Content);
+  END Log;
+  
+  FUNCTION Get_Msg RETURN VARCHAR2 IS
+    l_Msg_Count NUMBER;
+    l_Msg_Data  VARCHAR2(2000);
+  BEGIN
+    Fnd_Msg_Pub.Count_And_Get(p_Encoded => Fnd_Api.g_False
+                             ,p_Count   => l_Msg_Count
+                             ,p_Data    => l_Msg_Data);
+    IF l_Msg_Count > 1 THEN
+      l_Msg_Data := Fnd_Msg_Pub.Get_Detail(p_Msg_Index => Fnd_Msg_Pub.g_First
+                                          ,p_Encoded   => Fnd_Api.g_False);
+    END IF;
+    RETURN Substr(l_Msg_Data, 1, 4000);
+  END;
+
+  PROCEDURE Set_Msg(p_Content IN VARCHAR2) IS
+  BEGIN
+    Xxcus_Api.Set_Message('XXCUS'
+                         ,'XXCUS_CUSTOM_MSG'
+                         ,p_Token1          => 'MSG'
+                         ,p_Token1_Value    => p_Content);
+  END;
+  /*==================================================
+  Description:
+      请求逻辑处理
+  History:
+      1.00  2026-04-07 10:03:20  admin  Creation
+  ==================================================*/
+  PROCEDURE Process_Request(p_Init_Msg_List IN VARCHAR2 DEFAULT Fnd_Api.g_False
+                           ,p_Commit        IN VARCHAR2 DEFAULT Fnd_Api.g_False
+                           ,x_Return_Status OUT NOCOPY VARCHAR2
+                           ,x_Msg_Count     OUT NOCOPY NUMBER
+                           ,x_Msg_Data      OUT NOCOPY VARCHAR2
+                           ,p_Parameter1    IN VARCHAR2) IS
+    l_Api_Name       CONSTANT VARCHAR2(30) := 'process_request';
+    l_Savepoint_Name CONSTANT VARCHAR2(30) := 'sp_process_request01';
+  BEGIN
+    -- start activity to create savepoint, check compatibility
+    -- and initialize message list, include debug message hint to enter api
+    x_Return_Status := Xxcus_Api.Start_Activity(p_Pkg_Name       => g_Pkg_Name
+                                               ,p_Api_Name       => l_Api_Name
+                                               ,p_Savepoint_Name => l_Savepoint_Name
+                                               ,p_Init_Msg_List  => p_Init_Msg_List);
+    IF (x_Return_Status = Fnd_Api.g_Ret_Sts_Unexp_Error) THEN
+      RAISE Fnd_Api.g_Exc_Unexpected_Error;
+    ELSIF (x_Return_Status = Fnd_Api.g_Ret_Sts_Error) THEN
+      RAISE Fnd_Api.g_Exc_Error;
+    END IF;
+    -- API body
+
+    -- logging parameters
+    IF l_Debug = 'Y' THEN
+      Log('p_parameter1 : ' || p_Parameter1);
+    END IF;
+
+    -- todo
+
+    -- API end body
+    -- end activity, include debug message hint to exit api
+    x_Return_Status := Xxcus_Api.End_Activity(p_Pkg_Name  => g_Pkg_Name
+                                             ,p_Api_Name  => l_Api_Name
+                                             ,x_Msg_Count => x_Msg_Count
+                                             ,x_Msg_Data  => x_Msg_Data);
+
+  EXCEPTION
+    WHEN Fnd_Api.g_Exc_Error THEN
+      Log(Dbms_Utility.Format_Error_Backtrace);    
+      x_Return_Status := Xxcus_Api.Handle_Exceptions(p_Pkg_Name       => g_Pkg_Name
+                                                    ,p_Api_Name       => l_Api_Name
+                                                    ,p_Savepoint_Name => l_Savepoint_Name
+                                                    ,p_Exc_Name       => Xxcus_Api.g_Exc_Name_Error
+                                                    ,x_Msg_Count      => x_Msg_Count
+                                                    ,x_Msg_Data       => x_Msg_Data);
+    WHEN Fnd_Api.g_Exc_Unexpected_Error THEN
+      Log(Dbms_Utility.Format_Error_Backtrace);
+      x_Return_Status := Xxcus_Api.Handle_Exceptions(p_Pkg_Name       => g_Pkg_Name
+                                                    ,p_Api_Name       => l_Api_Name
+                                                    ,p_Savepoint_Name => l_Savepoint_Name
+                                                    ,p_Exc_Name       => Xxcus_Api.g_Exc_Name_Unexp
+                                                    ,x_Msg_Count      => x_Msg_Count
+                                                    ,x_Msg_Data       => x_Msg_Data);
+    WHEN OTHERS THEN
+      Log(Dbms_Utility.Format_Error_Backtrace);    
+      x_Return_Status := Xxcus_Api.Handle_Exceptions(p_Pkg_Name       => g_Pkg_Name
+                                                    ,p_Api_Name       => l_Api_Name
+                                                    ,p_Savepoint_Name => l_Savepoint_Name
+                                                    ,p_Exc_Name       => Xxcus_Api.g_Exc_Name_Others
+                                                    ,x_Msg_Count      => x_Msg_Count
+                                                    ,x_Msg_Data       => x_Msg_Data);
+  END Process_Request;
+  /*==================================================
+  Description:
+      请求入口
+  History:
+      1.00  2026-04-07 10:03:20  admin  Creation
+  ==================================================*/
+  PROCEDURE Main(Errbuf       OUT VARCHAR2
+                ,Retcode      OUT VARCHAR2
+                ,p_Parameter1 IN VARCHAR2) IS
+    l_Api_Name      VARCHAR2(30) := 'Main';
+    l_Return_Status VARCHAR2(30);
+    l_Msg_Count     NUMBER;
+    l_Msg_Data      VARCHAR2(2000);
+    l_Requests      VARCHAR2(2000);
+  BEGIN
+    Retcode := '0';
+    -- concurrent header log
+    Xxcus_Conc_Utl.Log_Header;
+    -- conc body
+    -- call process request api
+    Process_Request(p_Init_Msg_List => Fnd_Api.g_True
+                   ,p_Commit        => Fnd_Api.g_True
+                   ,x_Return_Status => l_Return_Status
+                   ,x_Msg_Count     => l_Msg_Count
+                   ,x_Msg_Data      => l_Msg_Data
+                   ,p_Parameter1    => p_Parameter1);
+    IF l_Return_Status = Fnd_Api.g_Ret_Sts_Error THEN
+      RAISE Fnd_Api.g_Exc_Error;
+    ELSIF l_Return_Status = Fnd_Api.g_Ret_Sts_Unexp_Error THEN
+      RAISE Fnd_Api.g_Exc_Unexpected_Error;
+    END IF;
+
+    -- conc end body
+    -- concurrent footer log
+    Xxcus_Conc_Utl.Log_Footer;
+
+  EXCEPTION
+    WHEN Fnd_Api.g_Exc_Error THEN
+      Xxcus_Conc_Utl.Log_Message_List;
+      Retcode := '1';
+      Fnd_Msg_Pub.Count_And_Get(p_Encoded => Fnd_Api.g_False
+                               ,p_Count   => l_Msg_Count
+                               ,p_Data    => l_Msg_Data);
+      IF l_Msg_Count > 1 THEN
+        l_Msg_Data := Fnd_Msg_Pub.Get_Detail(p_Msg_Index => Fnd_Msg_Pub.g_First
+                                            ,p_Encoded   => Fnd_Api.g_False);
+      END IF;
+      Errbuf := l_Msg_Data;
+    WHEN Fnd_Api.g_Exc_Unexpected_Error THEN
+      Xxcus_Conc_Utl.Log_Message_List;
+      Retcode := '2';
+      Fnd_Msg_Pub.Count_And_Get(p_Encoded => Fnd_Api.g_False
+                               ,p_Count   => l_Msg_Count
+                               ,p_Data    => l_Msg_Data);
+      IF l_Msg_Count > 1 THEN
+        l_Msg_Data := Fnd_Msg_Pub.Get_Detail(p_Msg_Index => Fnd_Msg_Pub.g_First
+                                            ,p_Encoded   => Fnd_Api.g_False);
+      END IF;
+      Errbuf := l_Msg_Data;
+    WHEN OTHERS THEN
+      Fnd_Msg_Pub.Add_Exc_Msg(p_Pkg_Name       => g_Pkg_Name
+                             ,p_Procedure_Name => 'MAIN'
+                             ,p_Error_Text     => Substrb(SQLERRM, 1, 240));
+      Xxcus_Conc_Utl.Log_Message_List;
+      Retcode := '2';
+      Errbuf  := SQLERRM;
+  END Main;
+
+END xxcust_test_pkg;


### PR DESCRIPTION
## 问题描述

`.pck`（Package Complete）格式文件无法被插件识别和解析。

## 根本原因

发现了两个独立的问题：

### 问题 1：`.pck` 扩展名未注册

扩展名 `.pck` 未在以下位置注册：
- `package.json` 语言定义 `languages.extensions`
- `package.json` 菜单条件正则及默认文件扩展名配置
- `src/extension.ts` 中两处硬编码扩展名列表

### 问题 2：带引号的 schema 限定标识符无法匹配

`.pck` 文件中的包名格式为 `"APPS"."XXCUST_TEST_PKG"`，所有 CREATE 语句的正则使用 `\w+`，无法匹配带引号的标识符，导致大纲视图为空。

## 修复内容

| 文件 | 修改内容 |
|---|---|
| `package.json` | 在语言定义、菜单条件、默认配置中加入 `.pck` |
| `src/extension.ts` | 两处硬编码扩展名列表加入 `.pck` |
| `src/patterns.ts` | 升级 5 个 CREATE 语句正则 |
| `src/parser.ts` | 升级 `matchCreateStatement`，支持 `"SCHEMA"."PKG_NAME"` 格式 |

## 支持的标识符格式

- `XXCUST_TEST_PKG` — 简单标识符
- `"XXCUST_TEST_PKG"` — 带引号标识符
- `APPS.XXCUST_TEST_PKG` — schema 前缀
- `"APPS"."XXCUST_TEST_PKG"` — 带引号的 schema 前缀

版本号从 1.4.8 升至 **1.4.9**。
